### PR TITLE
Add MacOS and Linux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,12 @@ Run the emulator, the buttons are controlled with `Z`, `X` and the `spacebar`.
 ### Windows
 Install the MSVC build tools for windows and run `build.bat` from the command line
 https://learn.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-170
-### Other OS's
-Not supported yet
+
+### Linux and MacOS
+**Note:** The emulator has only been tested on MacOS, and is quite unstable at the moment.
+
+Install the SDL2 development libraries and run `sh build.sh` from the command line.
+https://wiki.libsdl.org/SDL2/Installation
 
 ## Contributing
 Feel free to contribute by opening up a PR!

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Get SDL2 compiler and linker flags using sdl2-config
+SDL_CFLAGS=$(sdl2-config --cflags)
+SDL_LDFLAGS=$(sdl2-config --libs)
+
+# Define the compiler flags
+CFLAGS="$SDL_CFLAGS"
+LDFLAGS="$SDL_LDFLAGS"
+
+# Parse the command line arguments for custom definitions
+for arg in "$@"
+do
+    case $arg in
+        -DPRINT_STATE)
+        CFLAGS="$CFLAGS -DPRINT_STATE"
+        ;;
+        -DDISPLAY_FRAME_TIME)
+        CFLAGS="$CFLAGS -DDISPLAY_FRAME_TIME"
+        ;;
+        -DINIT_EEPROM)
+        CFLAGS="$CFLAGS -DINIT_EEPROM"
+        ;;
+        -Zi)
+        CFLAGS="$CFLAGS -g"
+        ;;
+    esac
+done
+
+# Create the bin directory if it doesn't exist
+mkdir -p bin
+
+# Compile the source files and link with SDL2
+gcc $CFLAGS -o bin/pokeStroller src/walker.c src/lin_main.c src/queue.c $LDFLAGS

--- a/src/lin_main.c
+++ b/src/lin_main.c
@@ -1,0 +1,138 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <SDL.h>
+#include "walker.h"
+
+#define TICKS_PER_SEC 4 /* RTC/4 */
+
+static bool walkerRunning;
+
+struct Vector2i {
+    union {
+        int x;
+        int width;
+    };
+    union {
+        int y;
+        int height;
+    };
+};
+
+float getEllapsedSeconds(Uint64 endPerformanceCount, Uint64 startPerformanceCount, Uint64 performanceFrequency) {
+    Uint64 ellapsedMicroSeconds = endPerformanceCount - startPerformanceCount;
+    return (float)ellapsedMicroSeconds / (float)performanceFrequency;
+}
+
+int main(int argc, char *argv[]) {
+    struct Vector2i nativeRes = { LCD_WIDTH, LCD_HEIGHT };
+    int scalingFactor = 4;
+
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_TIMER) != 0) {
+        printf("SDL_Init Error: %s\n", SDL_GetError());
+        return 1;
+    }
+
+    struct Vector2i screenRes = { nativeRes.width * scalingFactor, nativeRes.height * scalingFactor };
+    SDL_Window *win = SDL_CreateWindow("PokeStroller", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, screenRes.width, screenRes.height, SDL_WINDOW_SHOWN);
+    if (win == NULL) {
+        printf("SDL_CreateWindow Error: %s\n", SDL_GetError());
+        SDL_Quit();
+        return 1;
+    }
+
+    SDL_Renderer *ren = SDL_CreateRenderer(win, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
+    if (ren == NULL) {
+        SDL_DestroyWindow(win);
+        printf("SDL_CreateRenderer Error: %s\n", SDL_GetError());
+        SDL_Quit();
+        return 1;
+    }
+
+    void* bitMapMemory = malloc(nativeRes.width * nativeRes.height * 4);
+    if (bitMapMemory == NULL) {
+        printf("Memory allocation error\n");
+        SDL_DestroyRenderer(ren);
+        SDL_DestroyWindow(win);
+        SDL_Quit();
+        return 1;
+    }
+
+    SDL_Texture* texture = SDL_CreateTexture(ren, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, nativeRes.width, nativeRes.height);
+    if (texture == NULL) {
+        printf("SDL_CreateTexture Error: %s\n", SDL_GetError());
+        free(bitMapMemory);
+        SDL_DestroyRenderer(ren);
+        SDL_DestroyWindow(win);
+        SDL_Quit();
+        return 1;
+    }
+
+    initWalker();
+    walkerRunning = true;
+    uint64_t cycleCount = 0;
+
+    Uint64 performanceFrequency = SDL_GetPerformanceFrequency();
+    Uint64 startPerformanceCount = SDL_GetPerformanceCounter();
+
+    while (walkerRunning) {
+        SDL_Event e;
+        while (SDL_PollEvent(&e)) {
+            if (e.type == SDL_QUIT) {
+                walkerRunning = false;
+            }
+            if (e.type == SDL_KEYDOWN) {
+                uint8_t newInput = 0;
+                switch (e.key.keysym.sym) {
+                    case SDLK_SPACE:
+                        newInput |= ENTER;
+                        break;
+                    case SDLK_z:
+                        newInput |= LEFT;
+                        break;
+                    case SDLK_x:
+                        newInput |= RIGHT;
+                        break;
+                }
+                setKeys(newInput);
+            }
+        }
+
+        bool error = runNextInstruction(&cycleCount);
+        if (error) {
+            walkerRunning = false;
+        }
+
+        if (cycleCount >= SYSTEM_CLOCK_CYCLES_PER_SECOND / TICKS_PER_SEC) {
+            cycleCount -= SYSTEM_CLOCK_CYCLES_PER_SECOND / TICKS_PER_SEC;
+
+            quarterRTCInterrupt();
+            fillVideoBuffer(bitMapMemory);
+
+            SDL_UpdateTexture(texture, NULL, bitMapMemory, nativeRes.width * 4);
+            SDL_RenderClear(ren);
+            SDL_RenderCopy(ren, texture, NULL, NULL);
+            SDL_RenderPresent(ren);
+
+            float desiredFrameTimeInS = 1.0f / TICKS_PER_SEC;
+            Uint64 endPerformanceCount = SDL_GetPerformanceCounter();
+            float elapsedSeconds = getEllapsedSeconds(endPerformanceCount, startPerformanceCount, performanceFrequency);
+#ifdef DISPLAY_FRAME_TIME
+            printf("%f\n", elapsedSeconds);
+#endif
+            if (elapsedSeconds < desiredFrameTimeInS) {
+                SDL_Delay((Uint32)(1000.0f * (desiredFrameTimeInS - elapsedSeconds)));
+                endPerformanceCount = SDL_GetPerformanceCounter();
+            }
+            startPerformanceCount = endPerformanceCount;
+        }
+    }
+
+    free(bitMapMemory);
+    SDL_DestroyTexture(texture);
+    SDL_DestroyRenderer(ren);
+    SDL_DestroyWindow(win);
+    SDL_Quit();
+    return 0;
+}

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 void dumpArrayToFile(void* array, size_t size, char* fileName){
-	FILE* fileToWrite;
-	fopen_s(&fileToWrite, fileName,"wb");
-	fwrite(array, 1, size, fileToWrite);
-	fclose(fileToWrite);
+    FILE* fileToWrite;
+    fileToWrite = fopen(fileName, "wb");
+    fwrite(array, 1, size, fileToWrite);
+    fclose(fileToWrite);
 }


### PR DESCRIPTION
This pull request introduces a new SDL-based application, expanding Pokestroller's compatibility to MacOS and Linux platforms.

The code has been tested on MacOS, confirming that Pokestroller initializes correctly and that both the window and renderer are created without errors.

<img width="496" alt="image" src="https://github.com/jpcerrone/pokestroller/assets/173806915/750f2c1c-7d1e-46e0-b42c-ef239721fb46">

### Known Issues:
- **Screen Refresh Rate**: The refresh rate of the screens is slower than expected.
- **Emulator Stability**: The emulator crashes when buttons are pressed in quick succession. However I'm unable to find the cause yet.

Windows compatibility needs to be tested. Unfortunately, I am unable to verify this myself as I do not have access to a Windows PC.